### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-menu.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-menu.spec
+    - .packit.yaml
+
+upstream_package_name: deepin-menu
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-menu
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"0,/Version:/ s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-menu.spec"

--- a/rpm/deepin-menu.spec
+++ b/rpm/deepin-menu.spec
@@ -1,0 +1,43 @@
+Name:           deepin-menu
+Version:        5.0.1
+Release:        1%{?dist}
+Summary:        Deepin menu service
+License:        GPLv3+
+URL:            https://github.com/linuxdeepin/deepin-menu
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  desktop-file-utils
+BuildRequires:  pkgconfig(dtkwidget) >= 2.0.6
+BuildRequires:  pkgconfig(dframeworkdbus)
+BuildRequires:  pkgconfig(Qt5Gui)
+BuildRequires:  pkgconfig(Qt5DBus)
+BuildRequires:  pkgconfig(Qt5Widgets)
+BuildRequires:  pkgconfig(Qt5Multimedia)
+BuildRequires:  pkgconfig(Qt5MultimediaWidgets)
+BuildRequires:  pkgconfig(Qt5X11Extras)
+BuildRequires:  qt5-qtbase-private-devel
+
+%description
+Deepin menu service for building beautiful menus.
+
+%prep
+%autosetup -p1
+
+# Modify lib path to reflect the platform
+sed -i 's|/usr/bin|%{_libexecdir}|' data/com.deepin.menu.service \
+    deepin-menu.desktop deepin-menu.pro
+
+%build
+%qmake_qt5 DEFINES+=QT_NO_DEBUG_OUTPUT
+%make_build
+
+%install
+%make_install INSTALL_ROOT="%{buildroot}"
+
+%files
+%doc README.md
+%license LICENSE
+%{_libexecdir}/%{name}
+%{_datadir}/dbus-1/services/com.deepin.menu.service
+
+%changelog


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log: Initial packit setup
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>